### PR TITLE
Remove "Template: ItalyStrap"

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,7 +3,6 @@ Theme Name: ItalyStrap
 Theme URI: http://www.overclokk.net/italystrap-wordpress-starter-theme
 Author: Enea Overclokk
 Author URI: http://www.overclokk.net
-Template: ItalyStrap
 Description: Wordpess starter theme with twitter bootstrap, HTML5 boilerplate and Schema.org
 Version: 1.5.1
 License: MIT License (MIT)


### PR DESCRIPTION
That line tells WordPress that this is a Child Theme of ItalyStrap and tells you that the Parent Theme ItalyStrap is missing, while obviously that's not what a Starter Theme is supposed to do.
