### PR TITLE
Upgrade static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,14 @@
 		"lucatume/wp-browser": "~2.2",
 		"italystrap/debug": "~1.1",
 		"phpstan/phpstan": "^0.11.16",
-		"szepeviktor/phpstan-wordpress": "^0.2.1"
+		"szepeviktor/phpstan-wordpress": "^0.3.0"
 	},
 	"autoload": {
-		"classmap": [
-		],
 		"psr-4": {
 			"ItalyStrap\\": "src/"
 		}
 	},
-    "minimum-stability": "stable",
+	"minimum-stability": "stable",
 	"scripts": {
 		"test": [
 			".\\vendor\\bin\\phpstan analyse src/Builders --memory-limit=3G"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,26 +1,16 @@
 #$ composer update --optimize-autoloader
-#$ sed -e 's#^function is_countable(#// &#' -i vendor/giacocorsiglia/wordpress-stubs/wordpress-stubs.php
 #$ vendor/bin/phpstan analyze
 
 includes:
     # @see https://github.com/phpstan/phpstan/blob/master/conf/bleedingEdge.neon
-    # Regular phpstan installation
     - vendor/phpstan/phpstan/conf/bleedingEdge.neon
-    # PHAR installation
-    #- phar://phpstan.phar/conf/bleedingEdge.neon
-    # Include this extension
     - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
     level: max
     inferPrivatePropertyTypeFromConstructor: true
     paths:
         - %currentWorkingDirectory%/src/
-#    excludes_analyse:
-#    autoload_files:
-#        # Missing constants, function and class stubs
-#        - %currentWorkingDirectory%/tests/phpstan/bootstrap.php
-#        # Plugin stubs
-#        - %currentWorkingDirectory%/tests/phpstan/PLUGIN-stubs.php
+    autoload_files:
         # Procedural code
         - %currentWorkingDirectory%/functions/factory.php
     autoload_directories:
@@ -28,14 +18,3 @@ parameters:
     ignoreErrors:
         # Uses func_get_args()
         - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
-        - '#^Function do_action(_ref_array)? invoked with [3456] parameters, 1-2 required\.$#'
-        - '#^Function current_user_can invoked with 2 parameters, 1 required\.$#'
-        - '#^Function add_query_arg invoked with [123] parameters?, 0 required\.$#'
-        - '#^Function wp_sprintf invoked with [23456] parameters, 1 required\.$#'
-        - '#^Function add_post_type_support invoked with [345] parameters, 2 required\.$#'
-        - '#^Function ((get|add)_theme_support|current_theme_supports) invoked with [2345] parameters, 1 required\.$#'
-        # https://core.trac.wordpress.org/ticket/43304
-        - '/^Parameter #2 \$deprecated of function load_plugin_textdomain expects string, false given\.$/'
-        # WP-CLI accepts a class as callable
-        - '/^Parameter #2 \$callable of static method WP_CLI::add_command\(\) expects callable\(\): mixed, \S+ given\.$/'
-        # Please consider commenting ignores: issue URL or reason for ignoring

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,15 +6,16 @@ includes:
     - vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-    level: max
+# TODO    level: max
+    level: 4
     inferPrivatePropertyTypeFromConstructor: true
     paths:
         - %currentWorkingDirectory%/src/
+    excludes_analyse:
+        - %currentWorkingDirectory%/src/Customizer/settings/
     autoload_files:
         # Procedural code
-        - %currentWorkingDirectory%/functions/factory.php
-    autoload_directories:
-        - %currentWorkingDirectory%/src/
+        - %currentWorkingDirectory%/functions/autoload.php
     ignoreErrors:
         # Uses func_get_args()
-        - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
+        - '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'


### PR DESCRIPTION
phpstan-wordpress v0.3.0 depends on the `php-stubs/wordpress-stubs` which excludes deprecated and compat code.

Please consider correcting problems at least on @phpstan Level 2.